### PR TITLE
chore: move to scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'numpy >= 1.11.1',
         'pandas',
-        'sklearn',
+        'scikit-learn',
         'tensorflow',
         'tensorflow-probability',
         'tqdm',


### PR DESCRIPTION
This change migrates the repo to using scikit-learn as sklearn will be deprecated.

See: https://pypi.org/project/sklearn/