### PR TITLE
chore: update to scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'numpy >= 1.11.1',
         'pandas',
-        'sklearn',
+        'scikit-learn',
         'tensorflow',
         'tensorflow-probability',
         'tqdm',


### PR DESCRIPTION
sklearn is being deprecated (see: https://pypi.org/project/sklearn/) and  this dependency should be updated to point to scikit-learn to avoid installation failures during brownout/deprecation windows.

fixes #5 